### PR TITLE
Add goroutine safety warning. Tidy up mutexes. Return copy from Map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ generated/
 .vendor/
 bin/*
 gin-bin
+.idea/

--- a/envy.go
+++ b/envy.go
@@ -14,7 +14,7 @@ import (
 	"github.com/joho/godotenv"
 )
 
-var gil = &sync.Mutex{}
+var gil = &sync.RWMutex{}
 var env = map[string]string{}
 
 func init() {
@@ -24,6 +24,8 @@ func init() {
 
 // Load the ENV variables to the env map
 func loadEnv() {
+	gil.Lock()
+	defer gil.Unlock()
 	// Detect the Go version on the user system, not the one that was used to compile the binary
 	v := ""
 	out, err := exec.Command("go", "version").Output()
@@ -43,7 +45,7 @@ func loadEnv() {
 
 	if os.Getenv("GO_ENV") == "" {
 		if flag.Lookup("test.v") != nil {
-			Set("GO_ENV", "test")
+			env["GO_ENV"] = "test"
 		}
 	}
 
@@ -109,8 +111,8 @@ func Load(files ...string) error {
 // Get a value from the ENV. If it doesn't exist the
 // default value will be returned.
 func Get(key string, value string) string {
-	gil.Lock()
-	defer gil.Unlock()
+	gil.RLock()
+	defer gil.RUnlock()
 	if v, ok := env[key]; ok {
 		return v
 	}
@@ -120,8 +122,8 @@ func Get(key string, value string) string {
 // Get a value from the ENV. If it doesn't exist
 // an error will be returned
 func MustGet(key string) (string, error) {
-	gil.Lock()
-	defer gil.Unlock()
+	gil.RLock()
+	defer gil.RUnlock()
 	if v, ok := env[key]; ok {
 		return v, nil
 	}
@@ -152,8 +154,12 @@ func MustSet(key string, value string) error {
 
 // Map all of the keys/values set in envy.
 func Map() map[string]string {
-	gil.Lock()
-	defer gil.Unlock()
+	gil.RLock()
+	defer gil.RUnlock()
+	cp := map[string]string{}
+	for k, v := range env {
+		cp[k] = v
+	}
 	return env
 }
 
@@ -161,6 +167,7 @@ func Map() map[string]string {
 // those values temporarily during the run of the function.
 // At the end of the function run the copy is discarded and
 // the original values are replaced. This is useful for testing.
+// Warning: This function is NOT safe to use from a goroutine.
 func Temp(f func()) {
 	oenv := env
 	env = map[string]string{}
@@ -205,8 +212,8 @@ func CurrentPackage() string {
 }
 
 func Environ() []string {
-	gil.Lock()
-	defer gil.Unlock()
+	gil.RLock()
+	defer gil.RUnlock()
 	var e []string
 	for k, v := range env {
 		e = append(e, fmt.Sprintf("%s=%s", k, v))

--- a/envy.go
+++ b/envy.go
@@ -167,7 +167,8 @@ func Map() map[string]string {
 // those values temporarily during the run of the function.
 // At the end of the function run the copy is discarded and
 // the original values are replaced. This is useful for testing.
-// Warning: This function is NOT safe to use from a goroutine.
+// Warning: This function is NOT safe to use from a goroutine or
+// from code which may access any Get or Set function from a goroutine
 func Temp(f func()) {
 	oenv := env
 	env = map[string]string{}

--- a/envy_test.go
+++ b/envy_test.go
@@ -135,7 +135,7 @@ func Test_OverloadParams(t *testing.T) {
 func Test_ErrorWhenSingleFileLoadDoesNotExist(t *testing.T) {
 	r := require.New(t)
 	Temp(func() {
-		delete(Map(), "FLAVOUR")
+		delete(env, "FLAVOUR")
 		err := Load(".env.fake")
 
 		r.Error(err)


### PR DESCRIPTION
**This would possibly break existing code!**

I can't come up with a way to make the `Test()` function goroutine safe. Even adding a Mutex exclusively for `Test()` won't work because it could still race with a goroutine calling other Getter/Setter functions. Instead I've added a warning to the documentation for the Test function which addresses #13 

I've changed the mutex to an RWMutex since the map is safe for concurrent read, just not concurrent read/write. Assuming that most envy usage will be very read biased this should be worthwhile. 

I've made sure there is a mutex around every function which mutates or reads the env (Except for the `Temp()` function)

Lastly, and this is likely to be the problematic part, I've altered Map to return a copy since it doesn't make sense (at least to me) to wrap it up with a Mutex inside envy but then just hand it over to external code which can read/write from/to it however it pleases.