### PR TITLE
fix: ensure flag is true before setting GO_ENV

### DIFF
--- a/envy.go
+++ b/envy.go
@@ -42,7 +42,7 @@ func loadEnv() {
 	}
 
 	if os.Getenv("GO_ENV") == "" {
-		if flag.Lookup("test.v") != nil {
+		if v := flag.Lookup("test.v"); v != nil && v.Value.String() == "true" {
 			Set("GO_ENV", "test")
 		}
 	}


### PR DESCRIPTION
# Perceived Issue

This patch addresses, in my opinion, a transitive defect in `buffalo`, and while we could probably patch `buffalo` I believe this fix would be helpful for all downstream customers of `envy`. I might be completely wrong about this, I'm just trying to help and learn.

Currently, by default `buffalo task db:seed` operates on the `test` environment, and thus the `test` database. That's odd to me because the default `models.go` indicates the intention that `development` should be the default environment with the following snippet of code:

```go
env := envy.Get("GO_ENV", "development")
DB, err = pop.Connect(env)
```

With this patch we will continue to verify the existence of the flag `test.v`, but now we'll also verify that it is set to `true` before setting `GO_ENV` to `test`.


# How to Reproduce

### Env
```
$ go version
go version go1.10.2 darwin/amd64

$ buffalo version
INFO[0000] Buffalo version is: v0.11.1
```

### Steps
```
buffalo new coke
cd coke/
```

Add this to the `seed` grift:

```go
env := envy.Get("GO_ENV", "development")
log.Println("GO_ENV: ", env)
```

Then run the task:
```
$ buffalo task db:seed
2018/05/11 00:44:52 GO_ENV:  test
```