### PR TITLE
Fix unused variable bug in Map()

### DIFF
--- a/envy.go
+++ b/envy.go
@@ -168,7 +168,7 @@ func Map() map[string]string {
 	for k, v := range env {
 		cp[k] = v
 	}
-	return env
+	return cp
 }
 
 // Temp makes a copy of the values and allows operation on


### PR DESCRIPTION
In Map(), we create a copy of the `env` map to return to the user, but we end up returning our internal map instead. This fixes that bug and returns our copied map to the user.