### PR TITLE
envy.Mods() - Modify behavior to better match the current module auto…

### DIFF
--- a/envy.go
+++ b/envy.go
@@ -68,8 +68,16 @@ func loadEnv() {
 	}
 }
 
+// Mods returns true if module support is enabled, false otherwise
+// See https://github.com/golang/go/wiki/Modules#how-to-install-and-activate-module-support for details
 func Mods() bool {
-	return Get(GO111MODULE, "off") == "on"
+	go111 := Get(GO111MODULE, "")
+
+	if !InGoPath() {
+		return go111 != "off"
+	}
+
+	return go111 == "on"
 }
 
 // Reload the ENV variables. Useful if

--- a/envy_test.go
+++ b/envy_test.go
@@ -31,6 +31,10 @@ func Test_Mods(t *testing.T) {
 		r.False(Mods())
 		Set(GO111MODULE, "on")
 		r.True(Mods())
+		Set(GO111MODULE, "auto")
+		r.Equal(!InGoPath(), Mods())
+		Set(GO111MODULE, "")
+		r.Equal(!InGoPath(), Mods())
 	})
 }
 


### PR DESCRIPTION
…detection in place in go

Combined with packr2 this fixes an issue I was seeing with incorrect imports in main-packr.go.

This hung me up for a few hours today and may be the reason some others have ran into the same thing. The go devs have changed the module support to autodetect I think in 1.12 and imo we may want to keep pace with that as its what people are expecting to see. 

We could also improve this to only perform this auto detection if using 1.12 (or whatever version introduced the auto module support) if it is important to maintain behavior.