### PR TITLE
require explicit Load

### DIFF
--- a/envy.go
+++ b/envy.go
@@ -33,7 +33,6 @@ var env = map[string]string{}
 const GO111MODULE = "GO111MODULE"
 
 func init() {
-	Load()
 	loadEnv()
 }
 

--- a/envy_test.go
+++ b/envy_test.go
@@ -122,12 +122,12 @@ func Test_CurrentPackage(t *testing.T) {
 }
 
 // Env files loading
-func Test_LoadEnvLoadsEnvFile(t *testing.T) {
+func Test_LoadEnvNoImplicitLoad(t *testing.T) {
 	r := require.New(t)
 	Temp(func() {
-		r.Equal("root", Get("DIR", ""))
-		r.Equal("none", Get("FLAVOUR", ""))
-		r.Equal("false", Get("INSIDE_FOLDER", ""))
+		r.Equal("", Get("DIR", ""))
+		r.Equal("", Get("FLAVOUR", ""))
+		r.Equal("", Get("INSIDE_FOLDER", ""))
 	})
 }
 


### PR DESCRIPTION
Before this change, Load was always called in `init()`. This made it impossible to avoid replacing environment variables with values from `.env` in any program that imports `envy`, directly or indirectly.

See https://github.com/gobuffalo/packr/issues/191 for an example of where this causes problems.

After this change, programs that want this behavior can explicitly activate it by calling `envy.Load` in their `init() `functions.

This PR effectively reverts 15f5083a6e269f8698715b13dd25f0538754ab37.
