### PR TITLE
print error message on init failed

### DIFF
--- a/envy.go
+++ b/envy.go
@@ -33,7 +33,10 @@ var env = map[string]string{}
 const GO111MODULE = "GO111MODULE"
 
 func init() {
-	Load()
+	err := Load()
+	if err != nil {
+		fmt.Printf("unable to load env file(s): %s", err.Error())
+	}
 	loadEnv()
 }
 

--- a/envy.go
+++ b/envy.go
@@ -35,7 +35,7 @@ const GO111MODULE = "GO111MODULE"
 func init() {
 	err := Load()
 	if err != nil {
-		fmt.Printf("unable to load env file(s): %s", err.Error())
+		fmt.Printf("[ENVY] unable to load env file(s) on init: %s\n", err.Error())
 	}
 	loadEnv()
 }


### PR DESCRIPTION
somtimes it is hard to see syntax errors in .env files. this will help us to see loading errors on init. since we can't handle errors on init, had to use fmt.print