### PR TITLE
removed CurrentPackage() since envy only support go module mode

### DIFF
--- a/envy_test.go
+++ b/envy_test.go
@@ -106,9 +106,11 @@ func Test_GoPaths(t *testing.T) {
 	})
 }
 
-func Test_CurrentPackage(t *testing.T) {
+func Test_CurrentModule(t *testing.T) {
 	r := require.New(t)
-	r.Equal("github.com/gobuffalo/envy", CurrentPackage())
+	mod, err := CurrentModule()
+	r.NoError(err)
+	r.Equal("github.com/gobuffalo/envy", mod)
 }
 
 // Env files loading
@@ -210,5 +212,7 @@ func Test_GOPATH_Not_Set(t *testing.T) {
 		r.Equal("/go", Get("GOPATH", "notset"))
 	})
 
-	r.Equal("github.com/gobuffalo/envy", CurrentPackage())
+	mod, err := CurrentModule()
+	r.NoError(err)
+	r.Equal("github.com/gobuffalo/envy", mod)
 }


### PR DESCRIPTION
As of v1.7.1 it supports go 1.13 or higher and as of v1.9.0 `Mods()` was technically deprecated. However, we still have `CurrentPackge()` and it should be deprecated since the result of the function is not meaningful anymore.

This PR could be a breaking change but I would suggest removing the function as soon as possible and then I will track if there are some broken packages within gobuffalo projects as an additional task of https://github.com/gobuffalo/buffalo/issues/2152.

Fixes #37 